### PR TITLE
updated the version of jquery dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@material/dialog": "^0.44.0",
     "bootstrap": "^4.2.1",
     "config": "^3.0.1",
-    "jquery": "^1.9.1",
+    "jquery": ">=3.0.0",
     "json-server": "^0.14.2",
     "material-ui": "^0.20.2",
     "react": "^16.8.2",


### PR DESCRIPTION
jQuery before 3.0.0 is vulnerable to Cross-site Scripting (XSS) attacks when a cross-domain Ajax request is performed without the dataType option, causing text/javascript responses to be executed. 
Upgrade jquery to version 3.0.0 or later. For example:
"dependencies": {
  "jquery": ">=3.0.0"
}