### PR TITLE
update travis pipeline to build the react app then deploy the build artifact

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ deploy:
     on:
       branch:
         - dev
-        - feature/web-ui-travisci-upd
     skip_cleanup: true
     local_dir: build
   - provider: s3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: node_js
 node_js:
-  - node
-install: true
-script: skip
+  - "stable"
+install: 
+  - npm install
+script: 
+  - npm run build
 deploy:
   - provider: s3
     bucket: "ak-ui-dev-s3"
@@ -10,9 +12,11 @@ deploy:
     on:
       branch:
         - dev
+        - feature/web-ui-travisci-upd
   - provider: s3
     bucket: "ak-ui-prod-s3"
     region: us-east-2
     on:
       branch:
         - prod
+    local_dir: build

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ node_js:
 install: 
   - npm install
 script: 
-  - npm run build
+  - CI=false npm run build
 deploy:
   - provider: s3
     bucket: "ak-ui-dev-s3"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ deploy:
       branch:
         - dev
         - feature/web-ui-travisci-upd
+    skip_cleanup: true
     local_dir: build
   - provider: s3
     bucket: "ak-ui-prod-s3"
@@ -20,4 +21,5 @@ deploy:
     on:
       branch:
         - prod
+    skip_cleanup: true
     local_dir: build

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ deploy:
       branch:
         - dev
         - feature/web-ui-travisci-upd
+    local_dir: build
   - provider: s3
     bucket: "ak-ui-prod-s3"
     region: us-east-2


### PR DESCRIPTION
Working on Sprint 4 with production bucket I figured that I wasn't able to set up hosted website on s3 bucket. It was due to the fact that ui is done with react and needs to be build before being deployed. Current Travis Ci pipeline is configured to deploy everything on UI repository.
Solution: configure Travis CI yaml to
npm install 
npm run build
then deploy the build to bucket.

Solution:
I have updated yaml file to npm install then run build. Then as the build file gets created I set travis ci to not remove the build artifacts preserving the build directory and deploying the directory to s3 bucket.